### PR TITLE
Allow early setting of hash_salt

### DIFF
--- a/settings/misc.settings.php
+++ b/settings/misc.settings.php
@@ -22,7 +22,9 @@
  *   $settings['hash_salt'] = file_get_contents('/home/example/salt.txt');
  * @endcode
  */
-$settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
+if (empty($settings['hash_salt']) {
+  $settings['hash_salt'] = file_get_contents(DRUPAL_ROOT . '/../salt.txt');
+}
 
 /**
  * Deployment identifier.


### PR DESCRIPTION
This would allow https://github.com/acquia/blt/issues/4291 so that a previously-set hash salt (for example, from the Acquia require line, or from the new "early settings" file) to be used instead of the BLT-defined one. 